### PR TITLE
Make requirements forwards compatible with django.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8
+Django==1.8.4
 Jinja2==2.7.1
 MarkupSafe==0.18
 Pygments==1.6


### PR DESCRIPTION
Make things flexible for apps that use more recent versions of django.

If an application uses a tool such as [pip-compile](https://github.com/nvie/pip-tools), to seperate top level dependencies and sub dependencies, running pip-compile surfaces the issue that if the version of django used by app using this library and the version required by djangorest-alchemy may be different.

For e.g the following error shows up when running pip-compile for an application that uses django 1.8.4, but since djangoreset-alchemy pins the version to 1.8, pip-compile has issues resolving to the best version.

```
Could not find a version that matches django<1.9,==1.8,==1.8.4,>=1.3,>=1.4,>=1.5,>=1.7
```

@ashishgore Might need to make sure djangorest-alchemy actually works with more recent versions of django.
